### PR TITLE
ovn_kubernetes/index.rst: Fix docs build

### DIFF
--- a/doc/source/ovn_kubernetes/index.rst
+++ b/doc/source/ovn_kubernetes/index.rst
@@ -14,7 +14,6 @@
    docs/OVN-NORTHD.SSL.md
    docs/ci.md
    docs/config.md
-   docs/config.md
    docs/debugging.md
    docs/egress-firewall.md
    docs/ha.md


### PR DESCRIPTION
Fix duplicate line to avoid following build error:

    $ tox -e docs
    ...
    openshift_sdn_devel_docs/doc/source/ovn_kubernetes/index.rst:5:duplicated entry found in toctree: ovn_kubernetes/docs/config
    ERROR: InvocationError for command /home/vagrant/openshift_sdn_devel_docs/.tox/docs/bin/sphinx-build -W -b html doc/source doc/build/html (exited with code 2)